### PR TITLE
Add support for Periodic Madness.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.4.6
+Date: 2026-01-26
+  Mod Compatibility:
+    - Add support for Periodic Madness' two belts. (https://github.com/Pietersielie/BeltUpgrader/issues/69)
+  Bugfixes:
+    - Fix issue with Lignumis' Wood loader and AAI Loaders compatibility.
+---------------------------------------------------------------------------------------------------
 Version: 1.4.5
 Date: 2026-01-18
   Mod Compatibility:

--- a/control.lua
+++ b/control.lua
@@ -88,13 +88,18 @@ BigTableOfBelts["dredgeworks-floating-fast-transport-belt"] = {["transport-belt"
 BigTableOfBelts["dredgeworks-floating-express-transport-belt"] = {["transport-belt"] = "floating-express-transport-belt", ["underground-belt"] = "express-underground-belt", ["splitter"] = "express-splitter"} -- blue
 BigTableOfBelts["dredgeworks-floating-turbo-transport-belt"] = {["transport-belt"] = "floating-turbo-transport-belt", ["underground-belt"] = "turbo-underground-belt", ["splitter"] = "turbo-splitter"} -- green
 
--- AAI Loaders ()
+-- Periodic Madness (https://mods.factorio.com/mod/periodic-madness)
+BigTableOfBelts["periodic-madness-advanced-transport-belt"] = {["transport-belt"] = "pm-advanced-transport-belt", ["underground-belt"] = "pm-advanced-underground-belt", ["splitter"] = "pm-advanced-splitter"} -- red
+BigTableOfBelts["periodic-madness-high-density-transport-belt"] = {["transport-belt"] = "pm-high-density-transport-belt", ["underground-belt"] = "pm-high-density-underground-belt", ["splitter"] = "pm-high-density-splitter"} -- red
+
+-- AAI Loaders (https://mods.factorio.com/mod/aai-loaders)
 if (script.active_mods['aai-loaders']) then
 	BigTableOfBelts["transport-belt"]["loader1x1"] = "aai-loader"
 	BigTableOfBelts["fast-transport-belt"]["loader1x1"] = "aai-fast-loader"
 	BigTableOfBelts["express-transport-belt"]["loader1x1"] = "aai-express-loader"
 	BigTableOfBelts["turbo-transport-belt"]["loader1x1"] = "aai-turbo-loader"
 
+	-- Space Exploration
 	BigTableOfBelts["se-space-transport-belt"]["loader1x1"] = "aai-se-space-loader"
 	BigTableOfBelts["se-deep-space-transport-belt-black"]["loader1x1"] = "aai-se-deep-space-black-loader"
 	BigTableOfBelts["se-deep-space-transport-belt-blue"]["loader1x1"] = "aai-se-deep-space-blue-loader"
@@ -104,6 +109,10 @@ if (script.active_mods['aai-loaders']) then
 	BigTableOfBelts["se-deep-space-transport-belt-red"]["loader1x1"] = "aai-se-deep-space-red-loader"
 	BigTableOfBelts["se-deep-space-transport-belt-white"]["loader1x1"] = "aai-se-deep-space-white-loader"
 	BigTableOfBelts["se-deep-space-transport-belt-yellow"]["loader1x1"] = "aai-se-deep-space-yellow-loader"
+	
+	-- Lignumis
+	BigTableOfBelts["wood-transport-belt"]["loader1x1"] = "aai-wood-loader"
+	
 	if (script.active_mods['boblogistics']) then
 		BigTableOfBelts["turbo-transport-belt"]["loader1x1"] = nil
 		BigTableOfBelts["bob-basic-transport-belt"]["loader1x1"] = "aai-basic-loader"

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "BeltThreadUpgrades",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "factorio_version": "2.0",
   "title": "Spaghetti Belt Tools",
   "author": "PietersieliePC",


### PR DESCRIPTION
Mod Compatibility:
 - Add support for Periodic Madness' two belts. Resolves #69.

Bugfixes:
 - Fix issue with Lignumis' Wood loader and AAI Loaders compatibility.