### PR TITLE
Ugrade to Factorio version 2.1.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.6.0
+Date: 2026-06-27
+  Changes:
+    - Upgrade to Factorio version 2.1. (https://github.com/Pietersielie/BeltUpgrader/issues/80)
+    - Update belt access calls to account for new underground neighbour mechanic.
+    - Update pipe access calls to account for new fluidbox access.
+    - Update selection item filters to account for changes to default behaviours.
+---------------------------------------------------------------------------------------------------
 Version: 1.5.2
 Date: 2026-05-21
   Mod Compatibility:

--- a/control.lua
+++ b/control.lua
@@ -349,8 +349,8 @@ local function findAllConnectedBelts(belt, beltEntitiesToReturn, truthTable)
 	
 	-- Build downstream network
 	beltEntitiesToReturn = beltGraph.findDownstreamNetwork(belt, beltEntitiesToReturn, relBeltTier, truthTable)
-	if beltGraph.getType(belt) == "underground-belt" and belt.neighbours ~= nil then
-		beltEntitiesToReturn = beltGraph.findDownstreamNetwork(belt.neighbours, beltEntitiesToReturn, relBeltTier, truthTable)
+	if beltGraph.getType(belt) == "underground-belt" and belt.underground_belt_neighbour ~= nil then
+		beltEntitiesToReturn = beltGraph.findDownstreamNetwork(belt.underground_belt_neighbour, beltEntitiesToReturn, relBeltTier, truthTable)
 	end
 	if (VERBOSE > 2) then
 		local down = table_size(beltEntitiesToReturn) - up
@@ -622,19 +622,19 @@ local function RemoveBeltNetwork(event, ForceBuild)
 
 				if beltType == "underground-belt" then
 					-- Determine direction of neighbour:
-					if entity.neighbours ~= nil then
+					if entity.underground_belt_neighbour ~= nil then
 						local outLocal = table_size(entity.belt_neighbours["outputs"])
-						local outNeighbour = table_size(entity.neighbours.belt_neighbours["outputs"])
+						local outNeighbour = table_size(entity.underground_belt_neighbour.belt_neighbours["outputs"])
 
 						-- Case: Flow is from local to neighbour
 						if (outNeighbour > 0 and not (outLocal > 0)) then
 							-- Search downstream from neighbour
-							transportBeltEntitiesToRemove = beltGraph.findRedundantNetwork(entity.neighbours, transportBeltEntitiesToRemove, relBeltTier, true)
+							transportBeltEntitiesToRemove = beltGraph.findRedundantNetwork(entity.underground_belt_neighbour, transportBeltEntitiesToRemove, relBeltTier, true)
 
 						-- Case: Flow is from neighbour to local
 						elseif (outLocal > 0 and not (outNeighbour > 0)) then
 							-- Search upstream from neighbour
-							transportBeltEntitiesToRemove = beltGraph.findRedundantNetwork(entity.neighbours, transportBeltEntitiesToRemove, relBeltTier, false)
+							transportBeltEntitiesToRemove = beltGraph.findRedundantNetwork(entity.underground_belt_neighbour, transportBeltEntitiesToRemove, relBeltTier, false)
 						-- Case: No flow between neighbours.
 						-- else
 							-- do nothing
@@ -677,20 +677,26 @@ local function findAllConnectedPipes(pipeEntity, pipeEntitiesToReturn, ForceRemo
 		return pipeEntitiesToReturn
 	end
 
-	local connectedPipelikes = pipeEntity.fluidbox.get_connections(1)
-	if (table_size(connectedPipelikes) > 2 and not ForceRemove) then
+	local connectedPipelikes = pipeEntity.get_fluid_box_pipe_connections(1)
+	local validConnections = {}
+	for _, con in pairs(connectedPipelikes) do
+		if con.target ~= nil then
+			validConnections[con.target.unit_number] = con.target
+		end
+	end
+	if ((table_size(validConnections) > 2) and not (ForceRemove) and not (table_size(pipeEntitiesToReturn) < 1)) then
 		return pipeEntitiesToReturn
 	end
 
 	pipeEntitiesToReturn[pipeEntity.unit_number] = pipeEntity
-	for _, fluidBox in pairs(connectedPipelikes) do
-		local boxOwnerType = fluidBox.owner.type
-		if beltGraph.isGhost(fluidBox.owner) then
-			boxOwnerType = fluidBox.owner.ghost_type
+	for _, connectedPipeLike in pairs(validConnections) do
+		local boxOwnerType = connectedPipeLike.type
+		if beltGraph.isGhost(connectedPipeLike) then
+			boxOwnerType = connectedPipeLike.ghost_type
 		end
 		if pipeSelectionTypeFilter[boxOwnerType] then
-			if pipeEntitiesToReturn[fluidBox.owner.unit_number] == nil then
-				pipeEntitiesToReturn = findAllConnectedPipes(fluidBox.owner, pipeEntitiesToReturn, ForceRemove)
+			if pipeEntitiesToReturn[connectedPipeLike.unit_number] == nil then
+				pipeEntitiesToReturn = findAllConnectedPipes(connectedPipeLike, pipeEntitiesToReturn, ForceRemove)
 			end
 		end
 	end

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "BeltThreadUpgrades",
-  "version": "1.5.2",
-  "factorio_version": "2.0",
+  "version": "1.6.0",
+  "factorio_version": "2.1",
   "title": "Spaghetti Belt Tools",
   "author": "PietersieliePC",
   "contact": "https://github.com/Pietersielie/BeltUpgrader",

--- a/prototypes/items.lua
+++ b/prototypes/items.lua
@@ -16,7 +16,7 @@ beltThreadUpgradeTool.icon_size = 60
 
 -- Default selection (Upgrade only connected belts of same tier)
 beltThreadUpgradeTool.select.cursor_box_type = "entity"
-beltThreadUpgradeTool.select.mode = "upgrade"
+beltThreadUpgradeTool.select.mode = {"upgrade", "friend", "buildable-type", "entity-ghost"}
 beltThreadUpgradeTool.select.entity_filter_mode = "whitelist"
 beltThreadUpgradeTool.select.tile_filter_mode = "whitelist"
 beltThreadUpgradeTool.select.entity_type_filters = beltSelectionTypeFilter
@@ -24,7 +24,7 @@ beltThreadUpgradeTool.select.border_color = {0, 0.8, 0}
 
 -- Alternate selection (Upgrade all belts connected to starting entity)
 beltThreadUpgradeTool.alt_select.cursor_box_type = "entity"
-beltThreadUpgradeTool.alt_select.mode = "upgrade"
+beltThreadUpgradeTool.alt_select.mode = {"upgrade", "friend", "buildable-type", "entity-ghost"}
 beltThreadUpgradeTool.alt_select.entity_filter_mode = "whitelist"
 beltThreadUpgradeTool.alt_select.tile_filter_mode = "whitelist"
 beltThreadUpgradeTool.select.entity_type_filters = beltSelectionTypeFilter
@@ -32,7 +32,7 @@ beltThreadUpgradeTool.alt_select.border_color = {0, 0.8, 0.8}
 
 -- Reverse selection (Downgrade connected belts of the same tier)
 beltThreadUpgradeTool.reverse_select = table.deepcopy(beltThreadUpgradeTool.select)
-beltThreadUpgradeTool.reverse_select.mode = "downgrade"
+beltThreadUpgradeTool.reverse_select.mode = {"downgrade", "friend", "buildable-type", "entity-ghost"}
 beltThreadUpgradeTool.reverse_select.border_color = {1, 0, 0}
 
 -- Alternate reverse selection (Downgrade all belts connected to starting entity)
@@ -49,23 +49,22 @@ beltThreadRemoveTool.icon_size = 60
 
 -- Default selection (Remove only connected belts of same tier)
 beltThreadRemoveTool.select.cursor_box_type = "entity"
-beltThreadRemoveTool.select.mode = "buildable-type"
+beltThreadRemoveTool.select.mode = {"deconstruct", "friend", "buildable-type", "entity-ghost"}
+beltThreadRemoveTool.select.ignore_cannot_select_tiles = true
 beltThreadRemoveTool.select.entity_filter_mode = "whitelist"
-beltThreadRemoveTool.select.tile_filter_mode = "whitelist"
 beltThreadRemoveTool.select.entity_type_filters = beltSelectionTypeFilter
 beltThreadRemoveTool.select.border_color = {1, 0, 0}
 
 -- Alternate selection (Remove all belts connected to starting entity)
 beltThreadRemoveTool.alt_select.cursor_box_type = "entity"
-beltThreadRemoveTool.alt_select.mode = "buildable-type"
+beltThreadRemoveTool.alt_select.mode = {"deconstruct", "friend", "buildable-type", "entity-ghost"}
+beltThreadRemoveTool.alt_select.ignore_cannot_select_tiles = true
 beltThreadRemoveTool.alt_select.entity_filter_mode = "whitelist"
-beltThreadRemoveTool.alt_select.tile_filter_mode = "whitelist"
 beltThreadRemoveTool.alt_select.entity_type_filters = beltSelectionTypeFilter
 beltThreadRemoveTool.alt_select.border_color = {0.8, 0, 0.8}
 
 -- Reverse selection (Removes pipes connected to starting entity, split to pipes with to three or more connections)
 beltThreadRemoveTool.reverse_select = table.deepcopy(beltThreadRemoveTool.select)
-beltThreadRemoveTool.reverse_select.tile_filter_mode = "whitelist"
 beltThreadRemoveTool.reverse_select.entity_type_filters = pipeSelectionTypeFilter
 beltThreadRemoveTool.reverse_select.border_color = {0, 0, 1}
 

--- a/scripts/belt-graph.lua
+++ b/scripts/belt-graph.lua
@@ -75,7 +75,7 @@ findUpstreamNetwork = function(belt, beltEntitiesToReturn, relBeltTable, truthTa
 
 	-- If underground-belt, add other end if it exists
 	if (beltType == "underground-belt") then
-		local UGBeltEnd = belt.neighbours
+		local UGBeltEnd = belt.underground_belt_neighbour
 		if (UGBeltEnd ~= nil) then
             if (VERBOSE > 2) then
                 game.print({"", "Underground belt has a neighbour."})
@@ -221,7 +221,7 @@ findDownstreamNetwork = function(belt, beltEntitiesToReturn, relBeltTable, truth
 	end
     -- If underground-belt, add other end if it exists
     if (beltType == "underground-belt") then
-        local UGBeltEnd = belt.neighbours
+        local UGBeltEnd = belt.underground_belt_neighbour
         if (UGBeltEnd ~= nil) then
             if (VERBOSE > 2) then
                 game.print({"", "Underground belt has a neighbour:", serpent.block(UGBeltEnd)})
@@ -444,7 +444,7 @@ findRedundantNetwork = function (belt, beltEntitiesToReturn, relBeltTable, UpDow
 			-- 	case: 1 input
 			elseif table_size(inputs) == 1 then
 				-- 		case: input and belt direction are the same, or neighbours == nil, or output == {}
-				if (inputs[1].direction == belt.direction) or (belt.neighbours == nil) or (belt.belt_neighbours["outputs"] == {}) then
+				if (inputs[1].direction == belt.direction) or (belt.underground_belt_neighbour == nil) or (belt.belt_neighbours["outputs"] == {}) then
 					-- add
 					-- continue recursion
 					beltEntitiesToReturn[belt.unit_number] = belt
@@ -537,7 +537,7 @@ findRedundantNetwork = function (belt, beltEntitiesToReturn, relBeltTable, UpDow
 
     -- If underground-belt, add other end if it exists
     if (beltType == "underground-belt") then
-        local UGBeltEnd = belt.neighbours
+        local UGBeltEnd = belt.underground_belt_neighbour
         if (UGBeltEnd ~= nil) then
             connectedBelts[UGBeltEnd.unit_number] = UGBeltEnd
         end


### PR DESCRIPTION
Changes:
    - Upgrade to Factorio version 2.1. Resolves #80.
    - Update belt access calls to account for new underground neighbour mechanic.
    - Update pipe access calls to account for new fluidbox access.
    - Update selection item filters to account for changes to default behaviours.